### PR TITLE
fix equivalent mapping of `playlists_by_volumes` and `live_performances` shelves

### DIFF
--- a/ytm/parsers/artist.py
+++ b/ytm/parsers/artist.py
@@ -145,6 +145,8 @@ def artist(data: dict) -> dict:
     {
         'featured_on':          'playlists',
         'fans_might_also_like': 'similar_artists',
+        'playlists_by_volumes': 'playlists',
+        'live_performances':    'videos',
     }
 
     for shelf_identifier in shelf_identifiers:


### PR DESCRIPTION

Equivalent upstream:
- https://github.com/tombulled/python-youtube-music/pull/34