### PR TITLE
Fix greedy regex

### DIFF
--- a/ytm/parsers/artist.py
+++ b/ytm/parsers/artist.py
@@ -362,7 +362,7 @@ def artist(data: dict) -> dict:
         if shelf_identifier not in shelf_identifiers:
             raise Exception \
             (
-                f'Unrecognised sheld identifier: {repr(shelf_identifier)}'
+                f'Unrecognised shelf identifier: {repr(shelf_identifier)}'
             )
 
         for shelf_item in shelf_contents:

--- a/ytm/parsers/artist.py
+++ b/ytm/parsers/artist.py
@@ -145,6 +145,7 @@ def artist(data: dict) -> dict:
     {
         'featured_on':          'playlists',
         'fans_might_also_like': 'similar_artists',
+        'live_performances':    'videos',
     }
 
     for shelf_identifier in shelf_identifiers:
@@ -349,6 +350,10 @@ def artist(data: dict) -> dict:
             shelf_identifier = shelf_identifier_map[shelf_identifier]
 
         if shelf_identifier == 'artist-made_playlists':
+            continue
+        if shelf_identifier.startswith('playlists_by_'):
+            # identifier include the name of the artist for their custom lists
+            # omit the artist name altogether to avoid format failing matching it
             continue
 
         if shelf_identifier == 'singles_&_eps':


### PR DESCRIPTION
backport changes:
- [tombulled/python-youtube-music@`6a84962` (#33)](https://github.com/tombulled/python-youtube-music/pull/33/commits/6a84962e3aeffdb424e0df625ffa8e08f89eab4b)

as replacement of
- #4 